### PR TITLE
Remove codecov token

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,5 +46,3 @@ jobs:
           name: coverage-data
       - name: Upload coverage report
         uses: codecov/codecov-action@v1.3.2
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos


### PR DESCRIPTION
- Remove codecov token.
- The token was only needed when the project was private.