### PR TITLE
Rework CLI

### DIFF
--- a/aiomysensors/cli/gateway_serial.py
+++ b/aiomysensors/cli/gateway_serial.py
@@ -4,7 +4,7 @@ import click
 from aiomysensors.gateway import Gateway
 from aiomysensors.transport.serial import SerialTransport
 
-from .helper import handle_gateway, run_gateway
+from .helper import run_gateway
 
 
 @click.command(options_metavar="<options>")
@@ -19,6 +19,11 @@ from .helper import handle_gateway, run_gateway
 @click.option("-p", "--port", required=True, help="Serial port of the gateway.")
 def serial_gateway(port: str, baud: int) -> None:
     """Start a serial gateway."""
-    transport = SerialTransport(port, baud)
-    gateway = Gateway(transport)
-    run_gateway(handle_gateway, gateway)
+
+    async def gateway_factory() -> Gateway:
+        """Return a gateway."""
+        transport = SerialTransport(port, baud)
+        gateway = Gateway(transport)
+        return gateway
+
+    run_gateway(gateway_factory)

--- a/aiomysensors/cli/helper.py
+++ b/aiomysensors/cli/helper.py
@@ -1,35 +1,39 @@
 """Provide CLI helpers."""
 import asyncio
 import logging
-from typing import Callable
+from typing import Awaitable, Callable
 
 from aiomysensors.exceptions import AIOMySensorsError
 from aiomysensors.gateway import Gateway
 
 LOGGER = logging.getLogger("aiomysensors")
 
+GatewayFactory = Callable[[], Awaitable[Gateway]]
 
-def run_gateway(handler: Callable, gateway: Gateway) -> None:
+
+def run_gateway(gateway_factory: GatewayFactory) -> None:
     """Run a gateway."""
     LOGGER.info("Starting gateway")
     try:
-        asyncio.run(start_gateway(handler, gateway))
+        asyncio.run(start_gateway(gateway_factory))
     except KeyboardInterrupt:
         pass
     finally:
         LOGGER.info("Exiting CLI")
 
 
-async def start_gateway(handler: Callable, gateway: Gateway) -> None:
+async def start_gateway(gateway_factory: GatewayFactory) -> None:
     """Start the gateway."""
     try:
-        await handler(gateway)
+        await handle_gateway(gateway_factory)
     except AIOMySensorsError as err:
         LOGGER.error("Error '%s'", err)
 
 
-async def handle_gateway(gateway: Gateway) -> None:
+async def handle_gateway(gateway_factory: GatewayFactory) -> None:
     """Handle the gateway calls."""
+    gateway = await gateway_factory()
+
     async with gateway:  # pragma: no cover
         async for msg in gateway.listen():
             level = logging.DEBUG if msg.message_type == 9 else logging.INFO

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -1,0 +1,11 @@
+"""Provide common fixtures for the CLI."""
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture(name="gateway_handler")
+def gateway_handler_fixture():
+    """Mock the CLI gateway handler."""
+    with patch("aiomysensors.cli.helper.handle_gateway") as handler:
+        yield handler

--- a/tests/cli/test_gateway_serial.py
+++ b/tests/cli/test_gateway_serial.py
@@ -1,6 +1,5 @@
 """Test the CLI for the serial gateway."""
-import asyncio
-from unittest.mock import AsyncMock, patch
+from unittest.mock import patch
 
 import pytest
 from click.testing import CliRunner
@@ -9,21 +8,14 @@ from aiomysensors.cli import cli
 from aiomysensors.exceptions import AIOMySensorsError
 
 
-@pytest.fixture(name="gateway_handler", autouse=True)
-def gateway_handler_fixture():
+@pytest.fixture(name="gateway_cli", autouse=True)
+def gateway_cli_fixture():
     """Mock the CLI gateway handler."""
-    with patch("aiomysensors.cli.gateway_serial.handle_gateway") as handler:
-        yield handler
-
-
-@pytest.fixture(name="serial", autouse=True)
-def serial_fixture():
-    """Mock the serial connection."""
-    mock_reader = AsyncMock(spec=asyncio.StreamReader)
-    mock_writer = AsyncMock(spec=asyncio.StreamWriter)
-    with patch("aiomysensors.transport.serial.open_serial_connection") as open_serial:
-        open_serial.return_value = (mock_reader, mock_writer)
-        yield open_serial
+    with patch(
+        "aiomysensors.cli.gateway_serial.Gateway", autospec=True
+    ) as gateway_class:
+        gateway = gateway_class.return_value
+        yield gateway
 
 
 def test_serial_gateway():


### PR DESCRIPTION
- Allow creating the transport and gateway in async context. This is required for objects that require the current event loop.