### PR TITLE
feat: make node battery level optional

### DIFF
--- a/src/aiomysensors/model/node.py
+++ b/src/aiomysensors/model/node.py
@@ -31,9 +31,11 @@ class Node(DataClassDictMixin):
         default="",
         metadata=field_options(deserialize=lambda x: "" if x is None else x),
     )
-    battery_level: int = field(
-        default=0,
-        metadata=field_options(deserialize=lambda x: min(max(x, 0), 100)),
+    battery_level: int | None = field(
+        default=None,
+        metadata=field_options(
+            deserialize=lambda x: None if x is None else min(max(x, 0), 100)
+        ),
     )
     heartbeat: int = 0
     sleeping: bool = False

--- a/tests/common.py
+++ b/tests/common.py
@@ -13,7 +13,7 @@ NODE_SERIALIZED = {
     "sketch_name": "",
     "node_id": 0,
     "heartbeat": 0,
-    "battery_level": 0,
+    "battery_level": None,
     "sleeping": False,
 }
 


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request.

  By submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/MartinHjelmare/aiomysensors/blob/main/.github/CODE_OF_CONDUCT.md).

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->
BREAKING CHANGE: The node battery level is now optional, and by default has the value `None`.

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following to merge this PR.

  Note that there is no problem if they are not checked when this PR is created.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `main` branch
- [x] This pull request follows the [contributing guidelines](https://github.com/MartinHjelmare/aiomysensors/blob/main/CONTRIBUTING.md).
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".

> - If pre-commit.ci is failing, try `pre-commit run -a` for further information.
> - If CI / test is failing, try `uv run pytest` for further information.

<!--
  🎉 Thank you for contributing!
-->
