### PR TITLE
feat: remove node heartbeat attribute

### DIFF
--- a/src/aiomysensors/model/node.py
+++ b/src/aiomysensors/model/node.py
@@ -37,7 +37,6 @@ class Node(DataClassDictMixin):
             deserialize=lambda x: None if x is None else min(max(x, 0), 100)
         ),
     )
-    heartbeat: int = 0
     sleeping: bool = False
     reboot: bool = field(
         default=False,

--- a/src/aiomysensors/model/protocol/protocol_20.py
+++ b/src/aiomysensors/model/protocol/protocol_20.py
@@ -230,7 +230,6 @@ class IncomingMessageHandler(IncomingMessageHandler15):
 
         node = gateway.nodes[message.node_id]
         node.sleeping = True
-        node.heartbeat = int(message.payload)
 
         return await cls._handle_sleep_buffer(gateway, message, message_buffer)
 

--- a/src/aiomysensors/model/protocol/protocol_22.py
+++ b/src/aiomysensors/model/protocol/protocol_22.py
@@ -47,9 +47,6 @@ class IncomingMessageHandler(IncomingMessageHandler21):
         if message.node_id not in gateway.nodes:
             raise MissingNodeError(message.node_id)
 
-        node = gateway.nodes[message.node_id]
-        node.heartbeat = int(message.payload)
-
         return message
 
     @classmethod

--- a/tests/common.py
+++ b/tests/common.py
@@ -12,7 +12,6 @@ NODE_SERIALIZED = {
     "node_type": 17,
     "sketch_name": "",
     "node_id": 0,
-    "heartbeat": 0,
     "battery_level": None,
     "sleeping": False,
 }
@@ -36,7 +35,6 @@ NODE_CHILD_SERIALIZED.update(
     {
         "sketch_version": "1.0.0",
         "sketch_name": "test node 0",
-        "heartbeat": 10,
         "battery_level": 100,
     },
 )

--- a/tests/fixtures/test_aiomysensors_persistence.json
+++ b/tests/fixtures/test_aiomysensors_persistence.json
@@ -2,7 +2,6 @@
   "0": {
     "battery_level": 0,
     "children": {},
-    "heartbeat": 0,
     "node_id": 0,
     "node_type": 18,
     "protocol_version": "2.2.0",
@@ -22,7 +21,6 @@
         }
       }
     },
-    "heartbeat": 0,
     "node_id": 1,
     "node_type": 17,
     "protocol_version": "2.3.2",

--- a/tests/model/protocol/test_protocol_22.py
+++ b/tests/model/protocol/test_protocol_22.py
@@ -23,21 +23,19 @@ PROTOCOL_VERSIONS_22.remove("2.1")
 @pytest.mark.usefixtures("command", "node_before")
 @pytest.mark.parametrize("message_schema", PROTOCOL_VERSIONS_22, indirect=True)
 @pytest.mark.parametrize(
-    ("command", "context", "node_before", "writes", "heartbeat"),
+    ("command", "context", "node_before", "writes"),
     [
         (
             Message(0, 255, 3, 0, 22, HEARTBEAT_PAYLOAD),  # command
             DefaultContext(),  # context
             NODE_CHILD_SERIALIZED,  # node_before
             [],  # writes
-            int(HEARTBEAT_PAYLOAD),  # heartbeat
         ),  # heartbeat
         (
             Message(0, 255, 3, 0, 22, HEARTBEAT_PAYLOAD),  # command
             pytest.raises(MissingNodeError),  # context
             None,  # node_before
             ["0;255;3;0;19;\n"],  # writes
-            None,  # heartbeat
         ),  # missing node
     ],
     indirect=["command", "node_before"],
@@ -45,16 +43,12 @@ PROTOCOL_VERSIONS_22.remove("2.1")
 async def test_heartbeat_response(
     context: AbstractContextManager,
     writes: list[str],
-    heartbeat: int,
     gateway: Gateway,
     transport: MockTransport,
 ) -> None:
     """Test internal heartbeat response command."""
     with context:
         await anext(gateway.listen())
-
-    for node in gateway.nodes.values():
-        assert node.heartbeat == heartbeat
 
     assert transport.writes == writes
 

--- a/tests/model/test_node.py
+++ b/tests/model/test_node.py
@@ -24,7 +24,6 @@ def test_dump(child: Child) -> None:
         sketch_name="test node 0",
         sketch_version="1.0.0",
         battery_level=100,
-        heartbeat=10,
     )
 
     node_dump = node.to_dict()
@@ -41,7 +40,6 @@ def test_load() -> None:
     assert node.sketch_name == "test node 0"
     assert node.sketch_version == "1.0.0"
     assert node.battery_level == 100
-    assert node.heartbeat == 10
     assert node.reboot is False
 
     children = node.children

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -30,6 +30,7 @@ async def test_persistence_load(mock_file: MagicMock, persistence_data: str) -> 
     node = nodes.get(1)
     assert node
     assert node.battery_level == 0
+    assert not hasattr(node, "heartbeat")
     assert node.children
     child = node.children.get(1)
     assert child


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request.

  By submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/MartinHjelmare/aiomysensors/blob/main/.github/CODE_OF_CONDUCT.md).

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->
BREAKING CHANGE: Remove the node heartbeat attribute. The MySensors protocol doesn't require the heartbeat message payload to have a specific meaning. It's not possible to use the payload as part of the node state.

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following to merge this PR.

  Note that there is no problem if they are not checked when this PR is created.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `main` branch
- [x] This pull request follows the [contributing guidelines](https://github.com/MartinHjelmare/aiomysensors/blob/main/CONTRIBUTING.md).
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".

> - If pre-commit.ci is failing, try `pre-commit run -a` for further information.
> - If CI / test is failing, try `uv run pytest` for further information.

<!--
  🎉 Thank you for contributing!
-->
